### PR TITLE
Updated deprecated run call with clr exit reason.

### DIFF
--- a/Cluster.WebCrawler/src/WebCrawler.CrawlService/CrawlerService.cs
+++ b/Cluster.WebCrawler/src/WebCrawler.CrawlService/CrawlerService.cs
@@ -24,7 +24,7 @@ namespace WebCrawler.CrawlService
 
         public Task Stop()
         {
-            return CoordinatedShutdown.Get(ClusterSystem).Run();
+            return CoordinatedShutdown.Get(ClusterSystem).Run(CoordinatedShutdown.ClrExitReason.Instance);
         }
     }
 }


### PR DESCRIPTION
The old Run call did not appear to require an exit reason. This was changed in Akka.NET but the example was still using the deprecated call. Just a minor thing but I spotted it so thought it best to update.